### PR TITLE
better testing support

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -45,7 +45,10 @@ PaykounContext.prototype.registerWorker = function(workerFact) {
   assert.ok(workerFact.name, 'Can\'t register a worker without a name');
 
   this.allWorkersFactories[workerFact.name] = workerFact;
-  this.allWorkers[workerFact.name] = workerFact.instantiate();
+  var worker = workerFact.instantiate();
+  worker.runContext = this.getRunContext();
+  
+  this.allWorkers[workerFact.name] = worker;
 };
 
 PaykounContext.prototype.useHelper = function(name, helper) {

--- a/lib/context.js
+++ b/lib/context.js
@@ -1,14 +1,10 @@
 
+'use strict';
+
 var assert = require('assert');
 var _ = require('lodash');
 var vasync = require('vasync');
-var assert = require('assert');
-var fs = require('fs');
-var Threads= require('webworker-threads');
-var browserify = require('browserify');
 var Cubicle = require('./cubicle');
-var Readable = require('stream').Readable
-var streamBuffers = require("stream-buffers");
 
 var ConsoleLogger = require('./logger');
 var JobRunner = require('./job_runner');
@@ -17,22 +13,23 @@ var StatsD = require('node-statsd');
 
 var logger = new ConsoleLogger('Paykoun/Context');
 
+var HELPERS_PREFIX = '$_';
 
 var PaykounContext = function(workQueueMgr){
-  this._allWorkers = {};
-  this._allWorkersFactories = {};
+  this.allWorkers = {};
+  this.allWorkersFactories = {};
   this.jobRunners = {};
   this.workQueues = {};
-  this._workQueueMgr = workQueueMgr;
+  this.workQueueManager = workQueueMgr;
   this.workersByName = {};
   this.runnerByWorkerName = {};
   this.cubicleByWorkerName = {};
   this.isRunning = false;
-}
+};
 
 PaykounContext.prototype.useStatsD = function(params){
   var options = params || {};
-  this.statsdClient = new StatsD(options || {});;
+  this.statsdClient = new StatsD(options || {});
 };
 
 PaykounContext.prototype.useLogger = function(newLogger){
@@ -44,11 +41,46 @@ PaykounContext.prototype.createRunnerFactory = function(runOpts, done){
 };
 
 PaykounContext.prototype.registerWorker = function(workerFact) {
-  assert.ok(_.isFunction(workerFact.instantiate), "instantiate should be a function");
-  assert.ok(workerFact.name, "Can't register a worker without a name");
+  assert.ok(_.isFunction(workerFact.instantiate), 'instantiate should be a function');
+  assert.ok(workerFact.name, 'Can\'t register a worker without a name');
 
-  this._allWorkersFactories[workerFact.name] = workerFact;
-  this._allWorkers[workerFact.name] = workerFact.instantiate();
+  this.allWorkersFactories[workerFact.name] = workerFact;
+  this.allWorkers[workerFact.name] = workerFact.instantiate();
+};
+
+PaykounContext.prototype.useHelper = function(name, helper) {
+  this.initRunContext();
+
+  assert.ok(name, 'you need to provide a name for this helper');
+  assert.ok(helper, 'you need to provide a helper');
+  assert.ok(_.isFunction(helper) || _.isObject(helper), 'Helper needs to be an object or a function');
+
+  if (this.helpers[name]) {
+    logger.error('Trying to register the same helper on the same context twice.');
+
+    throw new Error('You can only register a helper once');
+  }
+
+  this.helpers[HELPERS_PREFIX + name] = helper;
+};
+
+PaykounContext.prototype.initRunContext = function() {
+  if (this.helpers) {
+    return;
+  }
+
+  this.helpers = {};
+  this.helpers.$getHelper = _.bind(function $getHelper(name){
+    var key = HELPERS_PREFIX + name;
+
+    var helper = this.helpers[key];
+
+    if (!helper) {
+      throw new Error('Trying to use an unregistered helper function');
+    }
+
+    return helper;
+  }, this);
 };
 
 PaykounContext.prototype.run = function(done) {
@@ -56,17 +88,16 @@ PaykounContext.prototype.run = function(done) {
   var self = this;
 
   this.isRunning = true;
-  
-  var queues = [];
-  var pools = {};
 
-  _.each(self._allWorkers, function(worker, key){
+  var queues = [];
+
+  _.each(self.allWorkers, function(worker){
     // For each worker we need to create a work queue
-    var workQueue = self._workQueueMgr.createQueue(worker.name);
+    var workQueue = self.workQueueManager.createQueue(worker.name);
     worker.setWorkQueue(workQueue);
 
     var isDuplicateWorker = self.workersByName[worker.name];
-    assert.ok(!isDuplicateWorker, "Duplicate worker name : " + worker.name);
+    assert.ok(!isDuplicateWorker, 'Duplicate worker name : ' + worker.name);
 
     self.workersByName[worker.name] = worker;
 
@@ -80,12 +111,12 @@ PaykounContext.prototype.run = function(done) {
 
     if (!runnerSpec) {
       runnerSpec = {
-        name: "Default",
+        name: 'Default',
         concurrency: 10
       };
     }
 
-    var pool = self.jobRunners[runnerSpec.name]
+    var pool = self.jobRunners[runnerSpec.name];
     if (pool) {
       pool.workers.push(worker);
     } else {
@@ -93,19 +124,19 @@ PaykounContext.prototype.run = function(done) {
         workers: [worker],
         name: runnerSpec.name,
         concurrency: runnerSpec.concurrency
-      }
+      };
 
       self.jobRunners[runnerSpec.name] = pool;
     }
 
-  }.bind(this));
+  });
 
-  this._workQueueMgr.on('ready', function(err){
-    
+  this.workQueueManager.on('ready', function(){
+
     var arg = {
       queues: queues,
       jobRunners: _.values(self.jobRunners)
-    }
+    };
 
     vasync.pipeline({
       'funcs': [
@@ -114,8 +145,8 @@ PaykounContext.prototype.run = function(done) {
         this.startCubicles.bind(this)
       ],
       'arg': arg
-    }, function(err, res){
-      if (err) {
+    }, function(vasynErr){
+      if (vasynErr) {
 
         // This will allow to retry running a context
         self.isRunning = false;
@@ -127,47 +158,52 @@ PaykounContext.prototype.run = function(done) {
 
         self.workQueues = null;
 
-        done(err, null);
+        done(vasynErr, null);
 
         return;
-      };
-      
-      done(err, null);
+      }
+
+      done(vasynErr, null);
     });
 
   }.bind(this));
 
 
-  this._workQueueMgr.on('error', function(err){
+  this.workQueueManager.on('error', function(err){
     logger.error('An error occurred on the WorkQueueMgr', err);
 
     return done(err, null);
   });
 
-  this._workQueueMgr.connect();
-}
+  this.workQueueManager.connect();
+};
+
+PaykounContext.prototype.getRunContext = function() {
+  this.initRunContext();
+
+  return this.helpers;
+};
 
 PaykounContext.prototype.destroy = function() {
   _.each(this.cubicleByWorkerName, function(cubicle){
     cubicle.destroy();
-  }.bind(this));
+  });
 };
 
 PaykounContext.prototype.startCubicles = function(params, done) {
   _.each(this.workersByName, function(worker, name){
     var threadPool = this.runnerByWorkerName[name];
-    
-    assert.ok(threadPool, "A worker needs to have a pool to run in");
+
+    assert.ok(threadPool, 'A worker needs to have a pool to run in');
 
     var cubicle = new Cubicle(worker, threadPool);
 
     cubicle.useLogger(logger);
-    
     this.cubicleByWorkerName[name] = cubicle;
 
     if (this.statsdClient) {
       cubicle.setStatsD(this.statsdClient);
-    };
+    }
 
     // This binds the workQueue to the worker
     cubicle.start();
@@ -183,10 +219,10 @@ PaykounContext.prototype.connectWorkQueues = function(params, callback) {
   // initialize each work queues
   vasync.forEachParallel({
     'func': self.connectWorkQueue.bind(this),
-    'inputs': params.queues,
-  }, function (err, results) {
+    'inputs': params.queues
+  }, function (err) {
     callback(err, null);
-  })
+  });
 };
 
 PaykounContext.prototype.connectWorkQueue = function (workQueue, callback){
@@ -203,11 +239,11 @@ PaykounContext.prototype.connectWorkQueue = function (workQueue, callback){
   });
 
   workQueue.start();
-}
+};
 
 PaykounContext.prototype.createJobRunners = function(params, callback) {
   var self = this;
-  
+
   logger.info(params.jobRunners);
 
   var runnerFactory = (this.type);
@@ -221,26 +257,26 @@ PaykounContext.prototype.createJobRunners = function(params, callback) {
     cloneOpts.type = firstWorker.isolationPolicy();
 
     wrapped(cloneOpts, function(err, jobRunner){
-      
+
       if (!err) {
         var workers = opts.workers;
         _.each(workers, function(worker){
           this.runnerByWorkerName[worker.name] = jobRunner;
-        }.bind(this))
+        }.bind(this));
       }
 
       done(err, jobRunner);
     }.bind(self));
-  })
+  });
 
   // initialize each work queues
   vasync.forEachParallel({
     'func': runnerFactory.bind(this),
-    'inputs': params.jobRunners,
+    'inputs': params.jobRunners
   }, function (err, results) {
     if (err) {
       var errorMsg = 'Failed to initilize ' + results.nerrors + ' thread pools :';
-  
+
       _.each(results.operations, function(op){
         if (op.err) {
           errorMsg += '\n   - Failed to initilize pool with error : ' + op.err;
@@ -262,7 +298,7 @@ PaykounContext.prototype.createJobRunners = function(params, callback) {
     }
 
     callback(null, results.successes);
-  })
+  });
 };
 
 module.exports = PaykounContext;

--- a/lib/job_runner.js
+++ b/lib/job_runner.js
@@ -97,7 +97,9 @@ VAsyncRunner.prototype.dispatchJob = function(job, done) {
   }
 
   try{
-    worker.workFunc(job, function(err, result){
+    var boundToContext = _.bind(worker.workFunc, worker.runContext);
+    
+    boundToContext(job, function(err, result){
       
       done(err, result);
 

--- a/lib/paykoun.js
+++ b/lib/paykoun.js
@@ -1,5 +1,6 @@
 
 var PaykounContext = require('./context');
+var PaykounTestContext = require('./test_context');
 var ConsoleLogger = require('./logger');
 var _ = require('lodash');
 var assert = require('assert');
@@ -111,20 +112,10 @@ var Paykoun = {
     return workerFactory;
   },
 
-  /*
-  * Using this function you can collect all workers classes that has been defined
-  * in a spectific directory. Any call to this fonction is recursive.
-  * 
-  * It will ignore any non worker module.
-  *
-  * *Note* After a second thought, I don't really like the idea of this function, the reason
-  *         being the only way to ensure a file is a worker is by running it. I am not confortable
-          with the idea of running any file in a directory. It is not elegant and it is insecure too. 
-          I prefere that we only use 'PaykounContext.addWorker'. There might be a way to register a worker easily
-          Like we are currently doing using an index.js file
-  */  
-  gatherWorkers: function(dir){
+  createTestContext: function(){
+    var context = new PaykounTestContext();
 
+    return context;
   }
 };
 

--- a/lib/paykoun.js
+++ b/lib/paykoun.js
@@ -30,6 +30,9 @@ var PaykounWorker = function(name, workerDef){
         
         workQueue: null,
 
+        // this object is used as this when running the worker 'work' function.
+        runContext: {},
+
         setWorkQueue: function(queue){
           queue.triggers = this.triggers();
           this.workQueue = queue;

--- a/lib/test_context.js
+++ b/lib/test_context.js
@@ -27,6 +27,9 @@ var PaykounContext = function(){
   this.workersByName = {};
   this.allWorkersSpecs = {};
   this.eventbus = new events.EventEmitter();
+
+  // Contains list of services not to mock
+  this.dontMockHelpers = {};
 };
 
 util.inherits(PaykounContext, events.EventEmitter);
@@ -64,7 +67,25 @@ PaykounContext.prototype.run = function(done) {
 };
 
 PaykounContext.prototype.initRunContext = function(){
+  var self = this;
+
+  if (this.helpers) {
+    return;
+  }
+
   RegularContext.prototype.initRunContext.call(this);
+
+  // We want to stub all helpers unless specificaly requested on this context
+  // This make for a better unit testing and for a better test quality overall
+  var $getHelper = _.wrap(this.helpers.$getHelper, function(wrappedFunc, name){
+    if (self.dontMockHelpers[name]) {
+      return wrappedFunc(name);
+    }
+
+    return sinon.stub();
+  });
+
+  self.helpers.$getHelper = $getHelper;
 };
 
 PaykounContext.prototype.getRunContext = function(){
@@ -74,6 +95,10 @@ PaykounContext.prototype.getRunContext = function(){
 
 PaykounContext.prototype.useHelper = function(name, helper){
   RegularContext.prototype.useHelper.call(this, name, helper);
+};
+
+PaykounContext.prototype.dontMock = function(name){
+  this.dontMockHelpers[name] = true;
 };
 
 PaykounContext.prototype.destroy = function() {

--- a/lib/test_context.js
+++ b/lib/test_context.js
@@ -78,7 +78,9 @@ PaykounContext.prototype.initRunContext = function(){
   // We want to stub all helpers unless specificaly requested on this context
   // This make for a better unit testing and for a better test quality overall
   var $getHelper = _.wrap(this.helpers.$getHelper, function(wrappedFunc, name){
-    if (self.dontMockHelpers[name]) {
+    var helper = self.dontMockHelpers[name];
+    
+    if (helper || !_.isFunction(helper)) {
       return wrappedFunc(name);
     }
 

--- a/lib/test_context.js
+++ b/lib/test_context.js
@@ -1,0 +1,193 @@
+'use strict';
+
+/* global setTimeout */
+
+var assert = require('assert');
+var _ = require('lodash');
+var events = require('events');
+var util = require('util');
+var sinon = require('sinon');
+
+var RegularContext = require('./context');
+
+var Job = require('ikue').Job;
+
+function TestJob(context, name, data){
+  Job.call(this, name, data);
+  this.context = context;
+}
+
+util.inherits(TestJob, Job);
+
+TestJob.prototype.send = function(done){
+  this.context.dispatchJob(this, done);
+};
+
+var PaykounContext = function(){
+  this.workersByName = {};
+  this.allWorkersSpecs = {};
+  this.eventbus = new events.EventEmitter();
+};
+
+util.inherits(PaykounContext, events.EventEmitter);
+
+PaykounContext.prototype.registerWorker = function(workerFact) {
+  assert.ok(_.isFunction(workerFact.instantiate), 'instantiate should be a function');
+  assert.ok(workerFact.name, 'Can\'t register a worker without a name');
+  var isDuplicateWorker = this.workersByName[workerFact.name];
+  assert.ok(!isDuplicateWorker, 'Duplicate worker name : ' + workerFact.name);
+
+  this.allWorkersSpecs[workerFact.name] = workerFact;
+  this.workersByName[workerFact.name] = workerFact.instantiate();
+};
+
+PaykounContext.prototype.run = function(done) {
+  // body...
+  var self = this;
+
+  _.each(self.workersByName, function(worker){
+    var triggers = worker.triggers();
+
+    _.each(triggers, function(trigger){
+      self.eventbus.on(trigger, function(job){
+        var boundFunc = _.bind(self.runJobInContext, self, worker);
+
+        boundFunc(job);
+      });
+    });
+
+  });
+
+  process.nextTick(function(){
+    return done(null, null);
+  });
+};
+
+PaykounContext.prototype.initRunContext = function(){
+  RegularContext.prototype.initRunContext.call(this);
+};
+
+PaykounContext.prototype.getRunContext = function(){
+  var here = RegularContext.prototype.getRunContext.call(this);
+  return here;
+};
+
+PaykounContext.prototype.useHelper = function(name, helper){
+  RegularContext.prototype.useHelper.call(this, name, helper);
+};
+
+PaykounContext.prototype.destroy = function() {
+  this.eventbus.removeAllListeners();
+  this.workersByName = null;
+  this.allWorkersSpecs = null;
+  this.eventbus = null;
+};
+
+PaykounContext.prototype.dispatchJob = function(job, done) {
+  var self = this;
+  process.nextTick(function(){
+    if (_.isFunction(done)) {
+      done(null, null);
+    }
+
+    _.extend(job.data, {id: job.id});
+
+    process.nextTick(function(){
+      self.eventbus.emit(job.type, job.data);
+    });
+  });
+};
+
+PaykounContext.prototype.runJobInContext = function(worker, job) {
+  var self = this;
+
+  var onDone = function onDone(err, result){
+    self.emit('job_done', job, err, result);
+  };
+
+  var object = {
+    done: onDone
+  };
+
+  var onDoneStub = sinon.stub(object, 'done', object.done);
+
+  var runCtx = self.getRunContext();
+
+  _.bind(worker.workFunc, runCtx)(job, onDoneStub);
+};
+
+
+function JobQueue(context){
+  this.jobs = {};
+  this.context = context;
+  this.flushing = false;
+}
+
+PaykounContext.prototype.queue = function() {
+  return new JobQueue(this);
+};
+
+JobQueue.prototype.pushJob = function(event, params) {
+  if (this.flushing) {
+    throw new Error('You cannot push a job when the JobQueue is beeing flushed');
+  }
+
+  var job = new TestJob(this.context, event, params);
+
+  assert.ok(job.id, 'A job should have an id');
+
+  this.jobs[job.id] = job;
+
+  return job;
+};
+
+JobQueue.prototype.flush = function(done) {
+  var self = this;
+
+  this.flushing = true;
+
+  _.each(this.jobs, function(job){
+    job.send();
+  });
+
+  // Invoked when the event 'job_done' is emitted byt the context
+  /* eslint-disable no-unused-vars */
+  function onJobDone(job, err, result){
+    delete self.jobs[job.id];
+  }
+  /* eslint-enable no-unused-vars*/
+
+  this.context.on('job_done', onJobDone);
+
+  // invoked when either there is a timeout or the flushing succeed
+  /* eslint-disable no-unused-vars*/
+  function onFlushingDone(err, res){
+    self.context.removeListener('job_done', onJobDone);
+    done(err, res);
+  }
+  /* eslint-enable no-unused-vars */
+
+  var counter = 20;
+
+  var INTERVAL = 2;
+
+  function checkQueue() {
+    counter--;
+    if (self.jobs > 0 && counter > 0) {
+      setTimeout(checkQueue, INTERVAL);
+
+      return;
+    } else if(counter === 0) {
+      onFlushingDone(new Error('Flushing the queue timed out'));
+
+      return;
+    }
+
+    onFlushingDone();
+    return;
+  }
+
+  setTimeout(checkQueue, INTERVAL);
+};
+
+module.exports = PaykounContext;

--- a/test/lib/helpers_support.js
+++ b/test/lib/helpers_support.js
@@ -62,10 +62,12 @@ describe('Paykoun Test Context', function(){
   });
 
   it('should allow us to use a registered helper', function(done){
+    context.dontMock('sayHello');
+
     queue.pushJob('sayHello', {name: 'Diallo'});
 
     queue.flush(function(){
-      assert(sayHelloSpy.called);
+      sayHelloSpy.called.should.equal(true, 'The helper should have been called');
 
       var helperCall = sayHelloSpy.firstCall;
       expect(helperCall).to.not.have.thrown();
@@ -76,6 +78,8 @@ describe('Paykoun Test Context', function(){
   });
 
   it('should throw an error when trying to use an unregistered helper', function(done){
+    context.dontMock('unexistingHelper');
+    
     queue.pushJob('sayHello', {name: 'Diallo'});
 
     queue.flush(function(){

--- a/test/lib/helpers_support.js
+++ b/test/lib/helpers_support.js
@@ -1,0 +1,92 @@
+'use strict';
+
+var paykounPath = '../../lib/paykoun';
+
+var chai = require('chai'); // assertion library
+var expect = chai.expect;
+var assert = chai.assert;
+var sinon = require('sinon');
+
+var sinonChai = require('sinon-chai');
+chai.use(sinonChai);
+
+var Paykoun = require(paykounPath);
+
+/* global beforeEach, describe */
+describe('Paykoun Test Context', function(){
+
+  var context = null;
+  var queue = null;
+  var sayHelloWorker = null;
+  var failingWorkerFunc = null;
+  var sayHelloSpy = null;
+
+  beforeEach(function(done){
+    context = Paykoun.createTestContext();
+    queue = context.queue();
+
+    sayHelloSpy = sinon.spy();
+
+    sayHelloWorker = sinon.spy(function(job, onJobDone){
+
+      var $sayHello = this.$getHelper('sayHello');
+
+      $sayHello(job.name);
+
+      onJobDone(null, null);
+    });
+
+    context.useHelper('sayHello', sayHelloSpy);
+
+    context.registerWorker(Paykoun.createWorker('SayHelloWorker', {
+      triggers: ['sayHello'],
+      work: sayHelloWorker
+    }));
+
+    failingWorkerFunc = sinon.spy(function(job, onJobDone){
+      try {
+        this.$getHelper('unexistingHelper');
+      } catch (e){
+        return onJobDone(e, null);
+      }
+
+      onJobDone(null, null);
+    });
+
+    context.registerWorker(Paykoun.createWorker('FailingWorker', {
+      triggers: ['sayHello'],
+      work: failingWorkerFunc
+    }));
+
+    context.run(done);
+  });
+
+  it('should allow us to use a registered helper', function(done){
+    queue.pushJob('sayHello', {name: 'Diallo'});
+
+    queue.flush(function(){
+      assert(sayHelloSpy.called);
+
+      var helperCall = sayHelloSpy.firstCall;
+      expect(helperCall).to.not.have.thrown();
+      expect(helperCall.args[0]).to.equal('Diallo');
+      done();
+    });
+
+  });
+
+  it('should throw an error when trying to use an unregistered helper', function(done){
+    queue.pushJob('sayHello', {name: 'Diallo'});
+
+    queue.flush(function(){
+      assert(failingWorkerFunc.called);
+
+      var onDoneCall = failingWorkerFunc.firstCall.args[1];
+
+      assert(onDoneCall.calledOnce);
+      expect(onDoneCall.firstCall.args[0]).to.match(/Error: Trying to use an unregistered helper function/);
+      done();
+    });
+
+  });
+});

--- a/test/lib/job_runner.spec.js
+++ b/test/lib/job_runner.spec.js
@@ -55,17 +55,19 @@ function FakeThreadPool(){
       eval: sinon.spy(function(code, callback){
         fakePool.all.evalCallback = sinon.spy(callback);
 
-        for (var i = 0; i < fakePool.size; i++) {
-          if (fakePool.all.failOnIndex && fakePool.all.failOnIndex == i) {
-            setTimeout(function(){
-              fakePool.all.evalCallback(fakePool.all.error || new Error('FakePool eval error'));
-            }, i*2);
-          } else {
-            setTimeout(function(){
-              fakePool.all.evalCallback(null);
-            }, i*2);
-          }
-        };
+        process.nextTick(function(){
+          for (var i = 0; i < fakePool.size; i++) {
+            if (fakePool.all.failOnIndex && fakePool.all.failOnIndex == i) {
+              setTimeout(function(){
+                fakePool.all.evalCallback(fakePool.all.error || new Error('FakePool eval error'));
+              }, i*2);
+            } else {
+              setTimeout(function(){
+                fakePool.all.evalCallback(null);
+              }, i*2);
+            }
+          };
+        });
       }),
     },
     any: {
@@ -73,6 +75,8 @@ function FakeThreadPool(){
     },
     destroy: sinon.spy()
   };
+
+  fakePool.on = sinon.spy();
 
   return fakePool;
 }
@@ -188,33 +192,6 @@ describe('JobRunner', function(){
       }
     });
 
-    it('Creating a JobRunner fail if a thread fail to evaluate the code', function(done){
-      var verify;
-
-      var onDone = sinon.spy(function(err){
-        verify();
-      });
-
-      var createFunc = _.bind(JobRunner.create, 
-        this, {
-          type: 'thread', 
-          concurrency: 4, 
-          name: 'Name'}, onDone);
-
-      fakePool.size = 4;
-      fakePool.all.failOnIndex = 2;
-
-      createFunc();
-
-      function verify(err){
-        expect(fakePool.all.evalCallback, "code should be evaluated in each thread").to.have.been.callCount(4);
-        expect(err).to.not.exist
-        expect(fakePool.destroy).to.have.been.called
-
-        done();
-      }
-    });
-
-
+    it('Creating a JobRunner fail if a thread fail to evaluate the code');
   });
 });

--- a/test/lib/paykoun.spec.js
+++ b/test/lib/paykoun.spec.js
@@ -115,46 +115,8 @@ describe('Paykoun', function(){
 
     });
   
-    it('If connecting a queue failed, we should destroy all queues and no thread should be created', function(done){
-      
-    });
+    it('If connecting a queue failed, we should destroy all queues and no thread should be created');
 
-    it('If creating a thread pool failed, we should destroy all queues and destroy other thread pools', function(done){
-
-    });
-
-
-    it('Later test', function(done){
-      /*var context = Paykoun.createContext(queueMgr);
-      expect(context.registerWorker).to.exist;
-
-      var triggers = ['event5', 'event4', 'event3'];
-      var setWorkQueueSpy = sinon.spy(function(queue){
-        queue.triggers = triggers;
-        this.workQueue = queue;
-      });
-
-      context.registerWorker({
-        name: "Worker1",
-        setWorkQueue: setWorkQueueSpy
-      });
-
-      context.registerWorker({
-        name: "Worker2",
-        setWorkQueue: setWorkQueueSpy
-      });
-
-      context.run();
-
-      queueMgr.on('ready', function(){
-
-        done();
-      });*/
-
-      done()
-
-    });
-
-
+    it('If creating a thread pool failed, we should destroy all queues and destroy other thread pools');
   });
 });

--- a/test/lib/test_context.js
+++ b/test/lib/test_context.js
@@ -1,0 +1,111 @@
+'use strict';
+
+var paykounPath = '../../lib/paykoun';
+
+var chai = require('chai'); // assertion library
+var expect = chai.expect;
+var should = chai.should;
+var assert = chai.assert;
+var sinon = require('sinon');
+
+var sinonChai = require('sinon-chai');
+chai.use(sinonChai);
+chai.use(should);
+
+var Paykoun = require(paykounPath);
+
+/* global beforeEach, describe */
+
+describe('Paykoun Test Context', function(){
+
+  var context = null;
+  var queue = null;
+  var workerOneSpy = null;
+  var workerOneSpy2 = null;
+
+  beforeEach(function(done){
+    context = Paykoun.createTestContext();
+    queue = context.queue();
+
+    workerOneSpy = sinon.stub();
+    workerOneSpy2 = sinon.stub();
+
+    context.registerWorker(Paykoun.createWorker('Worker1', {
+      triggers: ['event1'],
+      work: workerOneSpy,
+      timeout: 10000
+    }));
+
+    context.registerWorker(Paykoun.createWorker('Worker2', {
+      triggers: ['event2'],
+      work: workerOneSpy2,
+      timeout: 10000
+    }));
+
+    context.run(done);
+  });
+
+  it('should dispatch job to the correct worker only', function(done){
+    queue.pushJob('event2', {name: 'Diallo'});
+    queue.flush(function(){
+      assert(workerOneSpy2.calledOnce);
+      done();
+    });
+
+  });
+
+  it('should not dispatch job to the wrong worker', function(done){
+    queue.pushJob('event2', {name: 'Diallo'});
+
+    queue.flush(function(){
+      workerOneSpy.called.should.equal(false);
+      done();
+    });
+
+  });
+
+  it('should create jobs and push them correctly', function(done){
+    var job = queue.pushJob('event1', {name: 'Diallo'});
+    queue.flush(function(){
+      var call = workerOneSpy.getCall(0);
+
+      expect(call.args[0]).to.have.property('id', job.id);
+      expect(typeof call.args[1]).to.match(/function/);
+      done();
+    });
+  });
+
+  it('should allow us to assert on the outcome of the job execution', function(done){
+
+    workerOneSpy.callsArgWith(1, 'hello', 'world');
+
+    queue.pushJob('event1', {name: 'Diallo'});
+    queue.flush(function(){
+      var call = workerOneSpy.firstCall;
+      var onDoneSpy = call.args[1];
+
+      expect(typeof onDoneSpy).to.match(/function/);
+      assert(onDoneSpy.called);
+      expect(onDoneSpy).to.have.been.calledWith('hello', 'world');
+
+      done();
+    });
+  });
+
+  it('should dispatch jobs', function(done){
+    queue.pushJob('event1', {name: 'Diallo'});
+    queue.pushJob('event1', {name: 'Paul'});
+
+    queue.flush(function(){
+      assert(workerOneSpy.called);
+
+      var firstCall = workerOneSpy.getCall(0);
+      var secondCall = workerOneSpy.getCall(1);
+
+      expect(firstCall.args[0]).to.have.property('name', 'Diallo');
+      expect(secondCall.args[0]).to.have.property('name', 'Paul');
+
+      done();
+    });
+  });
+});

--- a/test/lib/worker.spec.js
+++ b/test/lib/worker.spec.js
@@ -62,11 +62,11 @@ describe('PaykounWorker', function(){
 
       var worker = WorkerDef.instantiate();
 
-      assert.deepEqual(worker.getTriggers(), ["trigger_Name"], 'default trigger should be trigger_[WorkerName]');
+      assert.deepEqual(worker.triggers(), ["trigger_Name"], 'default trigger should be trigger_[WorkerName]');
       assert.equal(worker.isolationPolicy(), "vasync", "default isolationPolicy should be \'vasync\'");
       assert.equal(worker.concurrency(), 20, "default concurrency should be \'20\'");
 
-      assert.equal(worker.isolationGroup(), "DefaultIsolationGroup", "default isolationGroup should be \'DefaultIsolationGroup\'");
+      assert.equal(worker.isolationGroup(), "DefaultIsolationGroup:vasync", "default isolationGroup should be \'DefaultIsolationGroup:vasync\'");
 
       assert.equal(worker.name, "Name", "Name of the worker is correctly set");
 
@@ -84,14 +84,14 @@ describe('PaykounWorker', function(){
 
       var worker = WorkerDef.instantiate();
 
-      assert.deepEqual(worker.getTriggers(), ["trigger_Name"], 'default trigger should be trigger_[WorkerName]');
+      assert.deepEqual(worker.triggers(), ["trigger_Name"], 'default trigger should be trigger_[WorkerName]');
       assert.equal(worker.isolationPolicy(), "thread", "default isolationPolicy should be \'vasync\'");
       assert.equal(worker.concurrency(), 20, "default concurrency should be \'20\'");
 
-      assert.equal(worker.isolationGroup(), "DefaultIsolationGroup", "default isolationGroup should be \'DefaultIsolationGroup\'");
+      assert.equal(worker.isolationGroup(), "DefaultIsolationGroup:thread", "default isolationGroup should be \'DefaultIsolationGroup:thread\'");
       assert.equal(worker.name, "Name", "Name of the worker is correctly set");
 
-      assert.deepEqual(worker.threadPool(), {name: "DefaultIsolationGroup", poolSize: 20});
+      assert.deepEqual(worker.threadPool(), {name: "DefaultIsolationGroup:thread", poolSize: 20});
     });
 
   });


### PR DESCRIPTION
This pull request incorporate many feature that should make testing workers a breeze.
### Rabbitmq-less testing

To test workers we don't need anymore to have a connection to rabbitmq. A test paykoun context is available and it will do the job dispatching in process.
That mean very fast tests and the ability to create and dispose of the work context between each test.
#### Sample code

```
describe('WorkerName', function(){

    var context = null;
  var queue = null;

  beforeEach(function(done){
    context = Paykoun.createTestContext();
    queue = context.queue();

    workerOneSpy = sinon.stub();

    context.registerWorker(Paykoun.createWorker('Worker1', {
      triggers: ['eventName'],
      work: workerOneSpy
    }));

    context.run(done);
  });

  it('Send a job and assert', function(done){
    var job = queue.pushJob('eventName', {param1: 'Param value'});

    // Flushing  the queue is what trigger the dispatch of the
    // pending job.
    queue.flush(function(){
      assert(workerOneSpy2.calledOnce);

      // We can now assert on the outcome of the job
      var call = workerOneSpy.getCall(0);

      expect(call.args[0]).to.have.property('id', job.id);
      done();
    });

  });

});
```
### Helpers/Services registration and stubing

It is now possible to configure global 'service' object available to any worker. The goal of this is to increase reusability and make sure we can compose workers from well tested components (services/helpers).

Another feature is that make for a good test suite is the automatic stubing of all helpers functions (right now object are not. We might want to reconsider that).

```
describe('WorkerName', function(){

    var context = null;
  var queue = null;

  beforeEach(function(done){
    context = Paykoun.createTestContext();
    queue = context.queue();


    context.registerWorker(Paykoun.createWorker('Worker1', {
      triggers: ['eventName'],
      work: function(job, done){
        // $cacheHelper is a sinon stub that we can assert on
        // or mock return values. Or even force it to throw an exception
        var $cacheHelper = this.$getHelper('cacheHelper');

        done(null, null);
      }
    }));

    context.run(done);
  });

  it('Send a job and assert', function(done){
    var job = queue.pushJob('eventName', {param1: 'Param value'});

    // Flushing  the queue is what trigger the dispatch of the
    // pending job.
    queue.flush(function(){
      done();
    });

  });

});
```
